### PR TITLE
docs: update to format w/ docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # Getting Started with Identity Vault in @ionic/react
 
-This application walks through the basic setup and use of <a href="https://ionic.io/products/identity-vault" target="_blank">Ionic's Identity Vault</a> in an `@ionic/react` application. Rather than connecting to a back end service and storing user session data this application will just store information that you type in and tell it to store. Almost all of the work done here will be concentrated on a couple of files:
+In this tutorial we will walk through the basic setup and use of <a href="https://ionic.io/products/identity-vault" target="_blank">Ionic's Identity Vault</a> in an `@ionic/react` application.
 
-- `src/hooks/useVault.ts`: a custom React hook that abstracts the logic associated with using Identity Vault. Functions and state exported here model what might be done in a real application.
+The most common use case of Identity Vault is to connect to a back end service and store user session data. For the purpose of this tutorial, the application we build will not connect to an actual service. Instead, the application will simply store information that you type in and tell it to store.
 
-- `src/pages/Home.tsx`: the main view component will have several form controls that allow the user to manipulate the vault. An application would not typically do this. Rather, it would call the methods from `useVault()` within various workflows. In this "getting started" demo application, however, this allows us to easily play around with the various APIs to see how they behave.
+Almost all of the work done in this tutorial will be concentrated on a couple of files:
+
+- `src/hooks/useVault.ts`: A custom React hook that abstracts the logic associated with using Identity Vault. Functions and state exported here model what might be done in a real application.
+
+- `src/pages/Home.tsx`: The main view component will have several form controls that allow the user to manipulate the vault. An application would not typically do this. Rather, it would call the methods from `useVault()` within various workflows. In this "getting started" demo application, however, this allows us to easily play around with the various Identity Vault APIs to see how they behave.
 
 ## Generate the Application
 
-The first thing we need to do is generate our application.
+The first step to take is to generate our application:
 
 ```bash
 ionic start getting-started-iv-react blank --type=react
 ```
 
-Now that the application has been generated let's add the native platforms.
+Now that the application has been generated let's add the iOS and Android platforms.
 
 Open the `capacitor.config.ts` file and change the `appId` to something unique like `io.ionic.gettingstartedivreact`:
 
@@ -50,7 +54,11 @@ Finally, in order to ensure that the web application bundle is copied over each 
 
 ## Install Identity Vault
 
-In order to install Identity Vault you will need to use `ionic enterprise register` in order to register your product key. This will create a `.npmrc` file containing the product key. If you have already performed that step for your production application, you can just copy the `.npmrc` file from your production project. Since this application is for learning purposes only, you don't need to obtain another key. You can then install Identity Vault.
+In order to install Identity Vault you will need to use `ionic enterprise register` in order to register your product key. This will create a `.npmrc` file containing the product key.
+
+If you have already performed that step for your production application, you can just copy the `.npmrc` file from your production project. Since this application is for learning purposes only, you don't need to obtain another key.
+
+You can then install Identity Vault:
 
 ```bash
 npm install @ionic-enterprise/identity-vault@next
@@ -58,9 +66,9 @@ npm install @ionic-enterprise/identity-vault@next
 
 ## Create the Vault
 
-In this step, we will create the vault and test it by storing and retrieving a value from it. We will call this value `session` since storing session data in a vault is the most common use case of Identity Vault. However, it is certainly not the _only_ use case.
+In this step, we will create the vault and test it by storing and retrieving a value from it. This value will be called `session`, since storing session data in a vault is the most common use case of Identity Vault. However, it is certainly not the _only_ use case.
 
-First, create a file named `src/hooks/useVault.ts`. Within this file we will create a hook that defines the vault and functions that abstract all of the logic we need in order to interact with the vault.
+First, create a file named `src/hooks/useVault.ts`. Within this file we will create a hook that defines the vault and functions that abstract all of the logic we need in order to interact with the vault:
 
 ```TypeScript
 import { Capacitor } from '@capacitor/core';
@@ -106,13 +114,14 @@ export const useVault = () => {
 
 ```
 
-Let's look at this file section by section. The first thing we do is define a configuration for our vault. The `key` gives the vault a name. The other properties provide a default behavior for our vault. As we shall see later, the configuration can be changed as we use the vault.
+Let's look at this file section by section:
+
+The first thing we do is define a configuration for our vault. The `key` gives the vault a name. The other properties provide a default behavior for our vault. As we shall see later, the configuration can be changed as we use the vault.
 
 ```TypeScript
 const config: IdentityVaultConfig = {
   key: 'io.ionic.getstartedivreact',
   type: VaultType.SecureStorage,
-  deviceSecurityType: DeviceSecurityType.SystemPasscode,
   lockAfterBackgrounded: 2000,
   shouldClearVaultAfterTooManyFailedAttempts: true,
   customPasscodeInvalidUnlockAttempts: 2,
@@ -120,23 +129,13 @@ const config: IdentityVaultConfig = {
 };
 ```
 
-Next we define a key for storing data. All data within the vault is stored as a key-value pair and you can store multiple key-value pairs within a single vault.
+Next, we define a key for storing data. All data within the vault is stored as a key-value pair and you can store multiple key-value pairs within a single vault.
 
 ```TypeScript
 const key = 'sessionData';
 ```
 
-We then create a hook that creates and memoizes our vault. Note that we are using the `BrowserVault` class when the application is running on the web. The `BrowserVault` allows us to continue to use our normal web-based development workflow.
-
-```TypeScript
-const vault = useMemo(() => {
-  return Capacitor.getPlatform() === 'web'
-    ? new BrowserVault(config)
-    : new Vault(config);
-}, []);
-```
-
-The hook additionally contains a state property that will be used to reflect the current `session` data to the outside world. It returns our `session` as well as functions that are used to store and restore our session.
+Then, we create a hook that creates and memoizes our vault.
 
 ```TypeScript
 export const useVault = () => {
@@ -156,7 +155,23 @@ export const useVault = () => {
 };
 ```
 
-:::note::: It's recommended to abstract vault functionality into functions that define how the rest of the application should interact with the vault instead of directly returning the `vault` instance. This creates more maintainable and debuggable code, while preventing the rest of the code from being exposed to potential API changes and reduces the chance of duplicating code.
+The hook additionally contains a state property that will be used to reflect the current `session` data to the outside world. It returns our `session` as well as functions that are used to store and restore our session.
+
+:::note
+It's recommended to abstract vault functionality into functions that define how the rest of the application should interact with the vault instead of directly returning the `vault` instance. This creates more maintainable and debuggable code, while preventing the rest of the code from being exposed to potential API changes and reduces the chance of duplicating code.
+:::
+
+Note that we are using the `BrowserVault` class when the application is running on the web. The `BrowserVault` allows us to continue to use our normal web-based development workflow.
+
+```TypeScript
+return Capacitor.getPlatform() === 'web'
+  ? new BrowserVault(config)
+  : new Vault(config);
+```
+
+:::note
+The `BrowserVault` class allows developers to use their normal web-based development workflow. It does **not** provide locking or security functionality.
+:::
 
 Now that we have the vault in place, let's switch over to `src/pages/Home.tsx` and implement some simple interactions with the vault. Here is a snapshot of what we will change:
 
@@ -164,7 +179,7 @@ Now that we have the vault in place, let's switch over to `src/pages/Home.tsx` a
 2. Import and make use of the `useVault()` hook
 3. Add a local state value called `data`
 
-When we are done, the file will look like this:
+Update the `Home` component to match the following code:
 
 ```TSX
 import React, { useState } from 'react';
@@ -241,9 +256,11 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
-:::note::: Throughout the rest of this guide only new markup or required code will be provided. It is up to you to make sure that the correct imports and component definitions are added.
+:::note
+Throughout the rest of this tutorial only new markup or required code will be provided. It is up to you to make sure that the correct imports and component definitions are added.
+:::
 
-Build this and run it on your device(s). You should be able to enter some data and store it in the vault by clicking "Set Session Data." If you then shutdown the app and start it again, you should be able to restore it using "Restore Session Data."
+Build the application and run it on an iOS and/or Android device. You should be able to enter some data and store it in the vault by clicking "Set Session Data." If you then shutdown the app and start it again, you should be able to restore it using "Restore Session Data."
 
 ## Locking and Unlocking the Vault
 
@@ -295,15 +312,17 @@ We can then add a couple of buttons to our `Home.tsx` component file:
 </IonItem>
 ```
 
-We can now lock and unlock the vault, though in our current case we cannot really tell. Our application should react in some way when the vault is locked. For example, we may want to clear specific data from memory. We may also wish to redirect to a page that will only allow the user to proceed if they unlock the vault. In our case, we will just clear the `session` and have a flag that we can use to visually indicate if the vault is locked or not. We can do that by using the vault's `onLock` event.
+We can now lock and unlock the vault, though in our current state we cannot really tell. Our application should react in some way when the vault is locked. For example, we may want to clear specific data from memory. We may also wish to redirect to a page that will only allow the user to proceed if they unlock the vault.
 
-First we need to add a state property to `useVault()` to track whether the vault is locked or not. Add the following code to `src/hooks/useVault.ts` under the declaration for `session`:
+In our case, we will just clear the `session` and have a flag that we can use to visually indicate if the vault is locked or not. We can do that by using the vault's `onLock` event.
+
+First, we need to add a state variable to track whether the vault is locked or not. Add the following code to `src/hooks/useVault.ts` under the declaration for `session`:
 
 ```TypeScript
 const [vaultIsLocked, setVaultIsLocked] = useState<boolean>(false);
 ```
 
-Next we need to handle events from the vault itself. Modify the `useMemo()` block of code:
+Next, the vault's `onLock` and `onUnlock` events need to be handled. Modify the `useMemo()` block of code:
 
 ```TypeScript
 const vault = useMemo(() => {
@@ -338,7 +357,7 @@ return {
 };
 ```
 
-Then update `Home.tsx` to display the `vaultIsLocked` value along with the session.
+Finally, update `Home.tsx` to display the `vaultIsLocked` value along with the session.
 
 ```JSX
 <IonItem>
@@ -349,19 +368,23 @@ Then update `Home.tsx` to display the `vaultIsLocked` value along with the sessi
 </IonItem>
 ```
 
-When the user presses the "Lock Vault" button, the "Session Data" will be cleared out and the "Vault is Locked" will show as true. Pressing "Unlock Vault" will cause "Vault is Locked" to show as false again. Pressing "Restore Session Data" will both unlock a vault and get the session data back.
+When the user presses the "Lock Vault" button, the "Session Data" will be cleared out. Pressing "Unlock Vault" will cause "Vault is Locked" to show as false again. Pressing "Restore Session Data" will both unlock a vault and get the session data back.
 
-:::note::: Vaults created with the `SecureStorage` vault type _do not_ lock. Data stored within this type of vault are still encrypted at rest and can be restored between sessions.
+In its current state, the vault is set to the `SecureStorage` vault type. We will be unable to observe any changes to the "Vault is Locked" value until we update the vault's configuration to a different vault type.
+
+:::note
+Vaults set to the `SecureStorage` vault type _do not_ lock. Data stored within this type of vault are still encrypted at rest and can be restored between sessions.
+:::
 
 In a few sections we will explore different vault types further, allowing us to test the ability to lock and unlock a vault. First, we will begin exploring the `Device` API.
 
-## The `Device` API
+## Device Level Capabilities
 
 Identity Vault allows you to have multiple vaults within your application. However, there are some capabilities that Identity Vault allows you to control that are applicable to the device that the application is running on rather than being applicable to any given vault. For these items, we will use Identity Vault's `Device` API.
 
 One such item is the "privacy screen". When an application is put into the background, the default behavior is for the OS to take a screenshot of the current page and display that as the user scrolls through the open applications. However, if your application displays sensitive information you may not want that information displayed at such a time. So, another option is to display the splash screen (on iOS) or a plain rectangle (on Android) instead of the screenshot. This is often referred to as a "privacy screen".
 
-We will use the `Device.isHideScreenOnBackgroundEnabled()` method to determine if our application will currently display the privacy screen or not. We will then use the `Device.setHideScreenOnBackground()` method to control whether it is displayed or not. Finally, we will hook that all up to a checkbox in the UI to allow the user to manipulate the value at run time.
+We will use the `Device.isHideScreenOnBackgroundEnabled()` method to determine if our application will currently display the privacy screen or not. Then we will use the `Device.setHideScreenOnBackground()` method to control whether it is displayed or not. Finally, we will hook that all up to a checkbox in the UI to allow the user to manipulate the value at run time.
 
 We only want to interact with the Device API if we are actually running on a device, so we will also use Ionic's platform detection features to avoid using the Device API when running on the web. Our app is not targeting the web; we just want to ensure we can still use a web based development flow.
 
@@ -377,13 +400,13 @@ import {
 import { Device } from '@ionic-enterprise/identity-vault';
 ```
 
-Next, add a constant `isMobile` above the `Home` component code:
+Next, a constant named `isMobile` is to be added _above_ the the `Home` component code:
 
 ```TypeScript
 const isMobile = isPlatform('hybrid');
 ```
 
-Then, add the following code to the `Home` component:
+Then, we will add logic to handle the privacy screen within the `Home` component:
 
 ```typescript
 const [privacyScreen, setPrivacyScreen] = useState<boolean>(false);
@@ -416,7 +439,7 @@ Build the app and play around with changing the checkbox and putting the app in 
 
 ## Using Different Vault Types
 
-The mechanism used to unlock the vault is determined by a combination of the `type` and the `deviceSecurityType` configuration settings.
+The mechanism used to unlock a vault is determined by a combination of the `type` and the `deviceSecurityType` configuration settings.
 
 The `type` setting can be set to any value from the `VaultType` enumeration:
 
@@ -425,7 +448,7 @@ The `type` setting can be set to any value from the `VaultType` enumeration:
 - `CustomPasscode`: When the vault is locked, it needs to be unlocked via a custom method provided by the application. This is typically done in the form of a custom PIN dialog.
 - `InMemory`: The data is never persisted. As a result, if the application is locked or restarted the data is gone.
 
-In addition to these types, the optional `deviceSecurityType` setting can be used to further refine the vault using a value from the `DeviceSecurity` enumeration:
+If `VaultType.DeviceSecurity` is used, the optional `deviceSecurityType` setting can further refine the vault by assigning a value from the `DeviceSecurity` enumeration:
 
 - `Biometrics`: Use the biometric authentication type specified by the device.
 - `SystemPasscode`: Use the system passcode entry screen.
@@ -454,7 +477,7 @@ In our application, we don't want to use every possible combination. Rather than
 
 Now we have the types defined within the domain of our application. The only code within our application that will have to worry about what this means within the context of the Identity Vault configuration is our `useVault()` hook.
 
-First, we will create a helper function in `src/hooks/useVault.ts` that takes in one of our application's types and returns the corresponding `VaultType` and `DeviceSecurityType`. This function will reside outside of the `useVault()` definition:
+First, create a custom type specific to our application along with a helper function in `src/hooks/useVault.ts`. This code will reside outside of the `useVault()` definition:
 
 ```TypeScript
 type LockType = 'NoLocking' | 'Biometrics' | 'SystemPasscode' | undefined;
@@ -480,7 +503,7 @@ const getConfigUpdates = (lockType: LockType) => {
 };
 ```
 
-Next, add a state property to `useVault()` just like the other ones that exist:
+Next, add a state variable to `useVault()` to track the lock type of the vault:
 
 ```TypeScript
 const [lockType, setLockType] = useState<LockType>(undefined);
@@ -547,7 +570,7 @@ Now when you run the app, you can choose a different locking mechanism and it sh
 
 If you change the vault type to use either Biometrics or Session Passcode, you should see that the vault is still using that mode when you restart the application. If a vault already exists for a given key (such as `'io.ionic.getstartedivreact'`), the vault remembers which mode it is operating in and will ignore the mode passed into the constructor.
 
-## Initialize the `vaultIsLocked` Flag
+## Current Lock Status
 
 Now that the vault type can be set to modes that lock, the "Lock Vault" and "Unlock Vault" buttons are now testable. However, try the following set of instructions:
 
@@ -559,7 +582,7 @@ Now that the vault type can be set to modes that lock, the "Lock Vault" and "Unl
 6. Press the "Restore Session Data" button.
 7. Observe the application request a security prompt.
 
-Clearly the vault was locked! Our flag is wrong because it's set to `false` on startup, and the `onLock` event does not trigger on startup. The `Vault` API provides a way to programmatically obtain the current lock status of the vault.
+Our flag is wrong because it's value is set to `false` on startup, and the `onLock` event does not trigger on startup. The `Vault` API provides a way to programmatically obtain the current lock status of the vault.
 
 Add the following line of code to `src/hooks/useVault.ts` immediately after the `onUnlock` event handler:
 
@@ -573,7 +596,7 @@ Now when the application is restarted, the vault should be shown as locked.
 
 In this final step, we will remove all items from the vault and then remove the vault itself. This can be achieved through the `Vault` API by calling the `clear()` method.
 
-To show this in action, add a `vaultExists` state property to the `useVault()` hook.
+To show this in action, add a `vaultExists` state property to the `useVault()` hook in `src/hooks/useVault.ts`:
 
 ```TypeScript
 const [vaultExists, setVaultExists] = useState<boolean>(false);
@@ -598,7 +621,16 @@ const exists = await vault.doesVaultExist();
 setVaultExists(exists);
 ```
 
-We should also add a call within the `useMemo()` code block to initialize the value along with the vault. Since that function is not `async` we need to use the "promise-then" syntax: `vault.doesVaultExist().then(setVaultExists)`;
+We should also add a call within the `useMemo()` code block to initialize the value along with the vault. Since that function is not `async` we need to use the "promise-then" syntax: `vault.doesVaultExist().then(setVaultExists)`:
+
+```TypeScript
+const vault = useMemo(() => {
+  ...
+  vault.doesVaultExist().then(setVaultExists);
+
+  return vault;
+}, []);
+```
 
 Once that all is in place, make the following adjustments to `src/pages/Home.tsx`:
 
@@ -607,6 +639,6 @@ Once that all is in place, make the following adjustments to `src/pages/Home.tsx
 
 ## Conclusion
 
-This guide has implemented using Identity Vault in a very manual manner, allowing for a lot of user interaction with the vault. In an actual application, a lot of this functionality would instead be a part of several programmatic workflows within the application.
+This "getting started" tutorial has implemented using Identity Vault in a very manual manner, allowing for a lot of user interaction with the vault. In an actual application, a lot of this functionality would instead be a part of several programmatic workflows within the application.
 
-At this point, you should have a good idea of how Identity Vault works. There is still more functionality that can be implemented. Be sure to check out our How To documentation to determine how to facilitate specific areas of functionality within your application.
+At this point, you should have a good idea of how Identity Vault works. There is still more functionality that can be implemented. Be sure to check out our documentation to determine how to facilitate specific areas of functionality within your application.


### PR DESCRIPTION
## What's Been Changed:

- Updated introduction to refer to the guide as a tutorial.
- Modified certain headings.
- Ensured `:` precede code blocks that readers are to write. `.` ends sentences when reviewing already written code.
- Renamed `setSession` to `storeSession`. `setSession` is "reserved" for the state variable.
- Formatted "Note" areas to match Docasaurus theme.  
- Extracted out switch case to convert "lock type" -> IV configuration into a helper function and TS type.
- Made mention that locking/unlocking will not work in `SecureStorage` mode.
- General grammar changes.

## What's Remaining

- Finalize tutorial using GA code.
- Align tutorial text between React/Angular/Vue for consistency.