### PR TITLE
fix(android): Add missing variables

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -11,4 +11,6 @@ ext {
     androidxJunitVersion = '1.1.3'
     androidxEspressoCoreVersion = '3.4.0'
     cordovaAndroidVersion = '10.1.1'
+    coreSplashScreenVersion = '1.0.0-rc01'
+    androidxWebkitVersion = '1.4.0'
 }


### PR DESCRIPTION
These two variables are missing in `variables.gradle`, `coreSplashScreenVersion` is used in the user gradle files, so the app fails to compile without it.